### PR TITLE
Added Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^8.2",
         "spatie/laravel-package-tools": "^1.16",
-        "illuminate/contracts": "^10.0||^11.0||^12.0",
+        "illuminate/contracts": "^10.0||^11.0||^12.0||^13.0",
         "livewire/livewire": "^3.0|^4.0"
     },
     "require-dev": {


### PR DESCRIPTION
## Summary
Adds support for Laravel 13.

## Changes
- Updated `illuminate/contracts` constraint to include `^13.0`

## Testing
- Tested on a fresh Laravel 13 project with PHP 8.4
- Package installs and works as expected